### PR TITLE
Fix search search results

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,10 +7,7 @@ Geocoder.configure(
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
 
-  # api_key: "#{ Rails.application.config.google_api_key }" #,   # API key for geocoding service
-  # TODO - get gecoder working with heroku and restricted api key
-  api_key: ENV['GOOGLEMAPS_API_KEY'],
-
+  api_key: ENV['GOOGLEMAPS_GEOCODING_API_KEY'],
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #keys)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -4,6 +4,7 @@ Geocoder.configure(
   lookup: :google,              # name of geocoding service (symbol)
   language: :en,                # ISO-639 language code
   use_https: true,              # use HTTPS for lookup requests? (if supported)
+  bounds: [[49.860538172861155, -6.2023046951665375], [61.12159479058175, 0.6450787158853796]],
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
 


### PR DESCRIPTION
The HTTP referrers restriction was not working for Geocoder. Using a separate API key for this enables a separate key to be used to the publicly visible JavaScript API key.

Also included in the PR is bounds option to favour UK search results. It is not clear whether this is actually working. If it is then it could be made configurable.